### PR TITLE
Add workflow to rebuild the caddy binary nightly and submit a PR if needed

### DIFF
--- a/.github/workflows/keep-binary-updated.yml
+++ b/.github/workflows/keep-binary-updated.yml
@@ -7,6 +7,7 @@ name: Keep binary updated
 # https://github.com/peter-evans/create-pull-request/blob/main/docs/examples.md#use-case-create-a-pull-request-to-modifyfix-pull-requests
 
 on:
+  workflow_dispatch:
   schedule:
     # Runs every night at 1:20am
     - cron: "20 1 * * *"

--- a/.github/workflows/keep-binary-updated.yml
+++ b/.github/workflows/keep-binary-updated.yml
@@ -1,0 +1,38 @@
+---
+name: Keep binary updated
+# Periodically rebuild from the upstream "latest" releases, then raise a new 
+# pull-request if the binary file changed.
+#
+# Cribs heavily from this example:
+# https://github.com/peter-evans/create-pull-request/blob/main/docs/examples.md#use-case-create-a-pull-request-to-modifyfix-pull-requests
+
+on:
+  schedule:
+    # Runs every night at 1:20am
+    - cron: "20 1 * * *"
+
+jobs:
+  keep-binary-up-to-date:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Regenerate binary
+        run: make
+      - name: Did anything change?
+        id: vars
+        run: |
+          branchname="binary-update/${{ github.head_ref }}"
+          echo "branchname=${branchname}" >> $GITHUB_OUTPUT
+          binaryupdated=$(git status --porcelain | cut -d ' ' -f 2 | wc -l)
+          echo "binaryupdated=${binaryupdated}" >> $GITHUB_OUTPUT
+      - name: Create PR with changes
+        if: steps.vars.outputs.binaryupdated != 0
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: Update binary for ${{ github.head_ref }}
+          title: Update binary for ${{ github.head_ref }}
+          body: This is an auto-generated PR to add an updated binary on ${{ github.head_ref }}.
+          labels: binary-update, automated pr
+          branch: ${{ steps.vars.outputs.branchname }}
+          base: ${{ github.head_ref }}
+

--- a/.github/workflows/keep-binary-updated.yml
+++ b/.github/workflows/keep-binary-updated.yml
@@ -9,8 +9,8 @@ name: Keep binary updated
 on:
   workflow_dispatch:
   schedule:
-    # Runs every night at 1:20am
-    - cron: "20 1 * * *"
+    # Runs every night around 4:20am EST/1:20am PST
+    - cron: "20 8 * * *"
 
 jobs:
   keep-binary-up-to-date:

--- a/.github/workflows/keep-binary-updated.yml
+++ b/.github/workflows/keep-binary-updated.yml
@@ -33,7 +33,7 @@ jobs:
           commit-message: Update binary for ${{ github.head_ref }}
           title: Update binary for ${{ github.head_ref }}
           body: This is an auto-generated PR to add an updated binary on ${{ github.head_ref }}.
-          labels: binary-update, automated pr
+          labels: binary-update, automated-pr
           branch: ${{ steps.vars.outputs.branchname }}
           base: ${{ github.head_ref }}
 


### PR DESCRIPTION
@JeanMarie-TTS and I determined that as of Caddy v2, everything is under the Apache license and there don't appear to be any restrictions on redistribution of binaries. So we can include our custom binary in the tree now! However, we don't want it to go out of date.

This PR adds a workflow to try building the binary every day (or when manually triggered), and then make a PR if the binary differs from what was already there.