### PR TITLE
Start including the binary in commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .DS_Store
 /todo.txt
 *.acl
-proxy/caddy


### PR DESCRIPTION
It's legit for a human to include a binary now, but also we have a workflow that checks for diffs when the binary is built, and it won't see any differences if the binary is ignored!