### PR TITLE
Bump to caddy 2.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # See "Adding custom Caddy modules" here:
 # https://hub.docker.com/_/caddy
 
-FROM caddy:2.5.1-builder AS builder
+FROM caddy:2.5.2-builder AS builder
 
 ARG GOARCH=amd64
 RUN xcaddy build \
     --with github.com/caddyserver/forwardproxy@caddy2
 
-FROM caddy:2.5.1-alpine
+FROM caddy:2.5.2-alpine
 
 RUN apk update
 RUN apk upgrade


### PR DESCRIPTION
[2.6.x is also available](https://github.com/caddyserver/caddy/releases/tag/v2.6.0), but it's a bigger change than [2.5.2](https://github.com/caddyserver/caddy/releases/tag/v2.5.2).