### PR TITLE
Update caddy to 2.6.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # See "Adding custom Caddy modules" here:
 # https://hub.docker.com/_/caddy
 
-FROM caddy:2.5.2-builder AS builder
+FROM caddy:2.6-builder AS builder
 
 ARG GOARCH=amd64
 RUN xcaddy build \
     --with github.com/caddyserver/forwardproxy@caddy2
 
-FROM caddy:2.5.2-alpine
+FROM caddy:2.6-alpine
 
 RUN apk update
 RUN apk upgrade


### PR DESCRIPTION
Both SemVer and [the release notes](https://github.com/caddyserver/caddy/releases/tag/v2.6.0) indicate that `2.6.x` only added features rather than breaking any backward compatibility. Note I'm specifying `2.6` rather than `2.6.4` because we want [our workflow that rebuilds the binary](https://github.com/GSA-TTS/cg-egress-proxy/blob/main/.github/workflows/keep-binary-updated.yml) to run whenever a new patchlevel release appears.