### PR TITLE
Update caddy to 2.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,6 @@ jobs:
       - name: build caddy - xcaddy build
         run: >
           xcaddy build
-          --with github.com/hairyhenderson/caddy-teapot-module@v0.0.3-0
           --with github.com/caddyserver/forwardproxy@caddy2
           --output proxy/caddy
       - name: validate Caddyfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # See "Adding custom Caddy modules" here:
 # https://hub.docker.com/_/caddy
 
-FROM caddy:2.7-builder AS builder
+FROM caddy:2.8-builder AS builder
 
 ARG GOARCH=amd64
 RUN xcaddy build \
     --with github.com/caddyserver/forwardproxy@caddy2
 
-FROM caddy:2.7-alpine
+FROM caddy:2.8-alpine
 
 RUN apk update
 RUN apk upgrade

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 # Build the caddy binary and copy it into the proxy subdirectory
 caddy-v2-with-forwardproxy: Dockerfile proxy/Caddyfile
 	docker compose build
-	docker compose up -d 
-	docker compose cp caddy:/usr/bin/caddy proxy/caddy
+	docker compose up -d
+	- docker compose cp caddy:/usr/bin/caddy proxy/caddy
 	docker compose down
 
 validate:
 	echo "test.gov" > allow.acl
 	echo "test.com" > deny.acl
-	sed -i 's/tls cert.pem key.pem/# tls cert.pem key.pem/g' proxy/Caddyfile
+	sed -i.bak 's/tls cert.pem key.pem/# tls cert.pem key.pem/g' proxy/Caddyfile && rm proxy/Caddyfile.bak
 	PORT=9999 PROXY_USERNAME=admin PROXY_PASSWORD=pass PROXY_PORTS=443 ./proxy/caddy validate --config proxy/Caddyfile
-	sed -i 's/# tls cert.pem key.pem/tls cert.pem key.pem/g' proxy/Caddyfile
-	rm allow.acl deny.acl
+	sed -i.bak 's/# tls cert.pem key.pem/tls cert.pem key.pem/g' proxy/Caddyfile
+	rm proxy/Caddyfile.bak allow.acl deny.acl

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,3 @@
----
-version: "3.7"
-
 services:
   caddy:
     build:
@@ -22,6 +19,7 @@ services:
       # The variables that matter to the app
       - PROXY_USERNAME=user
       - PROXY_PASSWORD=pass
+      - PROXY_PORTS=443
       - PROXY_DENY="*.yahoo.com"
       - PROXY_ALLOW= |
         "*.google.com


### PR DESCRIPTION
Changes:

* Updates binary to caddy 2.8
* Makes minor changes to allow local development to be a bit better on M1 macs, though `validate` is still broken due to incompatible architecture issues
* Removes the unused caddy-teapot module from the test github action

Marking this as draft until I'm able to deploy this to a known-working 2.7 proxy setup to verify no downstream surprises