### PR TITLE
Update actions version and config for signed commits

### DIFF
--- a/.github/workflows/keep-binary-updated.yml
+++ b/.github/workflows/keep-binary-updated.yml
@@ -16,7 +16,7 @@ jobs:
   keep-binary-up-to-date:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Regenerate binary
         run: make
       - name: Did anything change?
@@ -28,7 +28,7 @@ jobs:
           echo "binaryupdated=${binaryupdated}" >> $GITHUB_OUTPUT
       - name: Create PR with changes
         if: steps.vars.outputs.binaryupdated != 0
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v7
         with:
           commit-message: Update binary for ${{ github.ref_name }}
           title: Update caddy binary for ${{ github.ref_name }}
@@ -36,3 +36,4 @@ jobs:
           labels: binary-update, automated-pr
           branch: ${{ steps.vars.outputs.branchname }}
           base: ${{ github.ref_name }}
+          sign-commits: true


### PR DESCRIPTION
closes #76 

Screenshot showing a signed commit that was merged into this branch before force-pushing those commits away:
<img width="858" alt="Screenshot 2024-10-03 at 2 31 22 PM" src="https://github.com/user-attachments/assets/adb3534a-1781-4e81-a8dc-dde24e555f0b">
