### PR TITLE
Caddy 2.9 & local devex improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@
 FROM caddy:2.8-builder AS builder
 
 ARG GOARCH=amd64
+ARG GOOS=linux
 RUN xcaddy build \
     --with github.com/caddyserver/forwardproxy@caddy2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,18 +10,14 @@ RUN xcaddy build \
 
 FROM caddy:2.8-alpine
 
-RUN apk update
-RUN apk upgrade
-# Unclear whether we actually need this...
-RUN apk add nss-tools
+RUN apk add --no-cache jq curl
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 COPY Caddyfile /etc/caddy/Caddyfile
 COPY .profile /srv/.profile
-
-# This shouldn't be necessary once we have docker-compose properly calling our
-# .profile on startup; we do this here so that caddy will start up with our
-# Caddyfile, which refers to them.
-RUN touch /srv/allow.acl /srv/deny.acl
+COPY --chmod=0755 docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
 
 EXPOSE 8080
+
+ENTRYPOINT [ "/usr/bin/docker-entrypoint.sh" ]
+CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # See "Adding custom Caddy modules" here:
 # https://hub.docker.com/_/caddy
 
-FROM caddy:2.8-builder AS builder
+FROM caddy:2.9-builder AS builder
 
 ARG GOARCH=amd64
 ARG GOOS=linux
 RUN xcaddy build \
     --with github.com/caddyserver/forwardproxy@caddy2
 
-FROM caddy:2.8-alpine
+FROM caddy:2.9-alpine
 
 RUN apk add --no-cache jq curl
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
+GOOS?=linux
+GOARCH?=amd64
 # Build the caddy binary and copy it into the proxy subdirectory
 caddy-v2-with-forwardproxy: Dockerfile proxy/Caddyfile
-	docker compose build
+	docker compose build --build-arg GOOS=$(GOOS) --build-arg GOARCH=$(GOARCH)
 	docker compose up -d
 	- docker compose cp caddy:/usr/bin/caddy proxy/caddy
 	docker compose down
@@ -8,7 +10,13 @@ caddy-v2-with-forwardproxy: Dockerfile proxy/Caddyfile
 validate:
 	echo "test.gov" > allow.acl
 	echo "test.com" > deny.acl
-	sed -i.bak 's/tls cert.pem key.pem/# tls cert.pem key.pem/g' proxy/Caddyfile && rm proxy/Caddyfile.bak
 	PORT=9999 PROXY_USERNAME=admin PROXY_PASSWORD=pass PROXY_PORTS=443 ./proxy/caddy validate --config proxy/Caddyfile
-	sed -i.bak 's/# tls cert.pem key.pem/tls cert.pem key.pem/g' proxy/Caddyfile
-	rm proxy/Caddyfile.bak allow.acl deny.acl
+	rm allow.acl deny.acl
+
+build-caddy-apple-silicon: export GOOS=darwin
+build-caddy-apple-silicon: export GOARCH=arm64
+build-caddy-apple-silicon: caddy-v2-with-forwardproxy
+
+validate-apple-silicon: | build-caddy-apple-silicon validate
+	# rebuild binary for linux to ensure we dont accidentally commit the macOS version
+	make caddy-v2-with-forwardproxy

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,6 @@ services:
       # Solution to get Alpine to run the .profile comes from
       # https://stackoverflow.com/a/43743532/17138235
       - ENV=/srv/.profile
-      - https_proxy=https://localhost:8080
       # Provide the CF env fixtures... more are needed!
       - PORT=8080
 
@@ -20,6 +19,5 @@ services:
       - PROXY_USERNAME=user
       - PROXY_PASSWORD=pass
       - PROXY_PORTS=443
-      - PROXY_DENY="*.yahoo.com"
-      - PROXY_ALLOW= |
-        "*.google.com
+      - PROXY_DENY=translate.google.com
+      - PROXY_ALLOW=*.google.com

--- a/proxy/.profile
+++ b/proxy/.profile
@@ -31,19 +31,23 @@ ntnefina() {
 ntnefina deny.acl
 ntnefina allow.acl
 
-# Make it easy to run curl tests on ourselves
-https_proxy="https://$PROXY_USERNAME:$PROXY_PASSWORD@$(echo "$VCAP_APPLICATION" |  jq .application_uris[0] | sed 's/"//g'):61443"
+# Make it easy to run curl tests on ourselves both locally and deployed
+proxy_host="localhost"
+scheme="http"
+if [ -n "$VCAP_APPLICATION" ]; then
+  proxy_host=`echo "$VCAP_APPLICATION" | jq -r '.application_uris[0]'`
+  scheme="https"
+fi
+https_proxy="$scheme://$PROXY_USERNAME:$PROXY_PASSWORD@$proxy_host:$PORT"
 export https_proxy
 
 # Make open ports configurable via the PROXY_PORTS environment variable.
 # For example "80 443 22 61443". Default to 443 only.
 if [ -z "${PROXY_PORTS}" ]; then
-  PROXY_PORTS="443"
+  export PROXY_PORTS="443"
 fi
-export PROXY_PORTS
 
 echo
 echo
 echo "The proxy connection URL is:"
 echo "  $https_proxy"
-

--- a/proxy/.profile
+++ b/proxy/.profile
@@ -32,14 +32,15 @@ ntnefina deny.acl
 ntnefina allow.acl
 
 # Make it easy to run curl tests on ourselves both locally and deployed
+proxy_scheme="http"
 proxy_host="localhost"
-scheme="http"
+proxy_port="8080"
 if [ -n "$VCAP_APPLICATION" ]; then
+  proxy_scheme="https"
   proxy_host=`echo "$VCAP_APPLICATION" | jq -r '.application_uris[0]'`
-  scheme="https"
+  proxy_port="61443"
 fi
-https_proxy="$scheme://$PROXY_USERNAME:$PROXY_PASSWORD@$proxy_host:$PORT"
-export https_proxy
+export https_proxy="$proxy_scheme://$PROXY_USERNAME:$PROXY_PASSWORD@$proxy_host:$proxy_port"
 
 # Make open ports configurable via the PROXY_PORTS environment variable.
 # For example "80 443 22 61443". Default to 443 only.

--- a/proxy/docker-entrypoint.sh
+++ b/proxy/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# This entrypoint will facilitate a local Docker run of cg-egress-proxy coming as close as possible
+# to what happens on cloud.gov with the binary_buildpack
+
+# source .profile to set up allow.acl and deny.acl
+. .profile
+
+exec "$@"


### PR DESCRIPTION
closes #80 

changes:

* caddy 2.9 based
* fixes some issues with running proxy locally via docker, now properly sets everything up on a simple `docker compose up`
* adds a `make validate-apple-silicon` that allows running the existing make target while on an apple silicon mac.