### PR TITLE
Run PR-required actions on ready_for_review

### DIFF
--- a/.github/workflows/keep-binary-updated.yml
+++ b/.github/workflows/keep-binary-updated.yml
@@ -12,6 +12,10 @@ on:
     # Runs every night around 4:20am EST/1:20am PST
     - cron: "20 8 * * *"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   keep-binary-up-to-date:
     runs-on: ubuntu-latest
@@ -36,4 +40,5 @@ jobs:
           labels: binary-update, automated-pr
           branch: ${{ steps.vars.outputs.branchname }}
           base: ${{ github.ref_name }}
+          draft: always-true
           sign-commits: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,15 @@
 ---
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 jobs:
   test:

--- a/.github/workflows/validate-oscal.yml
+++ b/.github/workflows/validate-oscal.yml
@@ -1,6 +1,12 @@
 name: Validate OSCAL Assembly
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 permissions:
   contents: read


### PR DESCRIPTION
Currently, actions are not triggered for PRs that are automatically opened to update the caddy binary. This addresses that by:

* Opening those PRs in draft mode
* Updating the actions triggers to run after a person marks the automated PR as "ready for review"

There are [other options](https://github.com/peter-evans/create-pull-request/blob/v7/docs/concepts-guidelines.md#triggering-further-workflow-runs) to trigger the actions required to actually merge the PRs with our branch protections, but this seemed the least likely to cause longer-term issues around token ownership.