### PR TITLE
Support multiple `acl` sets per caddy instance

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Terraform Lint
+
+on:
+  push:
+    branches-ignore:
+      - main
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    name: Validate terraform configuration
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: terraform validate
+        uses: dflook/terraform-validate@v2
+
+  fmt-check:
+    runs-on: ubuntu-latest
+    name: Check formatting of terraform files
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: terraform fmt
+        uses: dflook/terraform-fmt-check@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
     branches-ignore:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ on:
       - reopened
       - ready_for_review
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test that caddy builds + Validate Caddyfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: build caddy - xcaddy build
         run: >
           xcaddy build
-          --with github.com/caddyserver/forwardproxy@caddy2
+          --with github.com/caddyserver/forwardproxy
           --output proxy/caddy
       - name: validate Caddyfile
         run: make validate

--- a/.github/workflows/test_tf.yml
+++ b/.github/workflows/test_tf.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_tf.yml
+++ b/.github/workflows/test_tf.yml
@@ -1,0 +1,20 @@
+name: Terraform Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Integration test
+    env:
+      TERRAFORM_PRE_RUN: |
+        apt-get update
+        apt-get install -y zip
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: terraform test
+        uses: dflook/terraform-test@v2

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.acl
 **/.trestle/cache/
 **/.trestle/_trash/
+dist/
+.terraform*
+*.tfstate*

--- a/Caddyfile.tftpl
+++ b/Caddyfile.tftpl
@@ -8,18 +8,26 @@
 }
 
 :{$PORT} {
+	route {
 %{ for config in configuration ~}
-	forward_proxy {
-		basic_auth "${config.user_name}" {$PROXY_PASSWORD_${config.safe_name}}
-		probe_resistance
-		acl {
-			%{ if length(config.denylist) > 0 }deny ${join(" ", config.denylist)}%{ endif }
-			%{ if length(config.allowlist) > 0 }allow ${join(" ", config.allowlist)}%{ endif }
-			deny all
+		forward_proxy {
+			basic_auth "${config.user_name}" {$PROXY_PASSWORD_${config.safe_name}}
+			probe_resistance
+			acl {
+				%{ if length(config.denylist) > 0 }deny ${join(" ", config.denylist)}%{ endif }
+				%{ if length(config.allowlist) > 0 }allow ${join(" ", config.allowlist)}%{ endif }
+				deny all
+			}
+			ports ${join(" ", config.ports)}
 		}
-		ports ${join(" ", config.ports)}
-	}
 %{ endfor ~}
+		forward_proxy {
+			basic_auth {$PROXY_RANDOM_USERNAME} {$PROXY_RANDOM_PASSWORD}
+			acl {
+				deny all
+			}
+		}
+	}
 	log {
 		format json
 		level {$CADDY_LOG_LEVEL:INFO}

--- a/Caddyfile.tftpl
+++ b/Caddyfile.tftpl
@@ -11,7 +11,7 @@
 	route {
 %{ for config in configuration ~}
 		forward_proxy {
-			basic_auth "${config.user_name}" {$PROXY_PASSWORD_${config.safe_name}}
+			basic_auth {$PROXY_USERNAME_${config.safe_name}} {$PROXY_PASSWORD_${config.safe_name}}
 			probe_resistance
 			acl {
 				%{ if length(config.denylist) > 0 }deny ${join(" ", config.denylist)}%{ endif }

--- a/Caddyfile.tftpl
+++ b/Caddyfile.tftpl
@@ -22,8 +22,12 @@
 		}
 %{ endfor ~}
 		forward_proxy {
+			# This last module serves to return a `407 Proxy Authentication Required` response
+			# to any clients that didn't send auth details originally. It is expected that no client
+			# is given the PROXY_RANDOM_USERNAME:PROXY_RANDOM_PASSWORD credentials
 			basic_auth {$PROXY_RANDOM_USERNAME} {$PROXY_RANDOM_PASSWORD}
 			acl {
+				# just in case the random creds do get out, don't allow any traffic via them
 				deny all
 			}
 		}

--- a/Caddyfile.tftpl
+++ b/Caddyfile.tftpl
@@ -1,0 +1,28 @@
+{
+	debug
+	log {
+		format console
+		level {$CADDY_LOG_LEVEL:INFO}
+	}
+	auto_https off
+}
+
+:{$PORT} {
+%{ for config in configuration ~}
+	forward_proxy {
+		basic_auth "${config.user_name}" {$PROXY_PASSWORD_${config.safe_name}}
+		probe_resistance
+		acl {
+			%{ if length(config.denylist) > 0 }deny ${join(" ", config.denylist)}%{ endif }
+			%{ if length(config.allowlist) > 0 }allow ${join(" ", config.allowlist)}%{ endif }
+			deny all
+		}
+		ports ${join(" ", config.ports)}
+	}
+%{ endfor ~}
+	log {
+		format json
+		level {$CADDY_LOG_LEVEL:INFO}
+		output stdout
+	}
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM caddy:2.9-builder AS builder
 ARG GOARCH=amd64
 ARG GOOS=linux
 RUN xcaddy build \
-    --with github.com/caddyserver/forwardproxy@caddy2
+    --with github.com/caddyserver/forwardproxy
 
 FROM caddy:2.9-alpine
 
@@ -20,4 +20,4 @@ COPY --chmod=0755 docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
 EXPOSE 8080
 
 ENTRYPOINT [ "/usr/bin/docker-entrypoint.sh" ]
-CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
+CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--watch"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apk add --no-cache jq curl
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 COPY Caddyfile /etc/caddy/Caddyfile
+COPY export_http_proxy.sh /srv/
 COPY .profile /srv/.profile
 COPY --chmod=0755 docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ caddy-v2-with-forwardproxy: Dockerfile proxy/Caddyfile
 validate:
 	echo "test.gov" > allow.acl
 	echo "test.com" > deny.acl
-	PORT=9999 PROXY_USERNAME=admin PROXY_PASSWORD=pass PROXY_PORTS=443 ./proxy/caddy validate --config proxy/Caddyfile
+	PORT=9999 PROXY_USERNAME=admin PROXY_PASSWORD=pass ./proxy/caddy validate --config proxy/Caddyfile
 	rm allow.acl deny.acl
 
 build-caddy-apple-silicon: export GOOS=darwin

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,15 +9,11 @@ services:
     volumes:
       - $PWD/proxy:/etc/caddy
     environment:
-      # Solution to get Alpine to run the .profile comes from
-      # https://stackoverflow.com/a/43743532/17138235
-      - ENV=/srv/.profile
       # Provide the CF env fixtures... more are needed!
       - PORT=8080
 
       # The variables that matter to the app
       - PROXY_USERNAME=user
       - PROXY_PASSWORD=pass
-      - PROXY_PORTS=443
       - PROXY_DENY=translate.google.com
       - PROXY_ALLOW=*.google.com

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,3 +17,7 @@ services:
       - PROXY_PASSWORD=pass
       - PROXY_DENY=translate.google.com
       - PROXY_ALLOW=*.google.com
+
+      # test export_http_proxy.sh
+      - PROXY_USERNAME_client=clientuser
+      - PROXY_PASSWORD_client=clientpass

--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,10 @@ resource "cloudfoundry_app" "egress_app" {
   strategy         = "rolling"
   enable_ssh       = var.enable_ssh
 
+  routes = [{
+    route = cloudfoundry_route.egress_route.url
+  }]
+
   environment = merge(
     {
       CADDY_LOG_LEVEL       = "INFO"
@@ -68,9 +72,6 @@ resource "cloudfoundry_route" "egress_route" {
   domain = data.cloudfoundry_domain.internal_domain.id
   space  = var.cf_egress_space.id
   host   = local.egress_host
-  destinations = [{
-    app_id = cloudfoundry_app.egress_app.id
-  }]
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,75 @@
+locals {
+  # Yields something like: orgname-spacename-name.apps.internal, limited to the last 63 characters
+  default_route_host = "${replace(var.cf_org_name, ".", "-")}-${replace(var.cf_egress_space.name, ".", "-")}-${var.name}"
+  egress_host        = replace(lower(substr(coalesce(var.route_host, local.default_route_host), -63, -1)), "/^[^a-z]*/", "")
+}
+
+resource "random_password" "password" {
+  for_each = var.client_configuration
+  length   = 16
+  special  = false
+}
+
+data "archive_file" "src" {
+  type        = "zip"
+  source_dir  = "${path.module}/proxy"
+  output_path = "${path.module}/dist/src.zip"
+  excludes    = ["docker-entrypoint.sh"]
+}
+
+locals {
+  configuration = { for name, config in var.client_configuration : name => merge(config, {
+    safe_name = replace(lower(name), "/[^a-z0-9_]+/", "_")
+    user_name = replace(name, ":", "")
+  }) }
+  environment_passwords = { for name, config in local.configuration : "PROXY_PASSWORD_${config.safe_name}" => random_password.password[name].result }
+}
+
+resource "cloudfoundry_app" "egress_app" {
+  name       = var.name
+  space_name = var.cf_egress_space.name
+  org_name   = var.cf_org_name
+
+  path             = data.archive_file.src.output_path
+  source_code_hash = data.archive_file.src.output_base64sha256
+  buildpacks       = ["binary_buildpack"]
+  command          = "./caddy run --config Caddyfile"
+  memory           = var.egress_memory
+  instances        = var.instances
+  strategy         = "rolling"
+  enable_ssh       = var.enable_ssh
+
+  environment = merge(
+    {
+      CADDY_LOG_LEVEL = "INFO"
+      CONFIG_CONTENT = templatefile("${path.module}/Caddyfile.tftpl", {
+        configuration = values(local.configuration)
+      })
+    },
+    local.environment_passwords
+  )
+}
+
+data "cloudfoundry_domain" "internal_domain" {
+  name = "apps.internal"
+}
+resource "cloudfoundry_route" "egress_route" {
+  domain = data.cloudfoundry_domain.internal_domain.id
+  space  = var.cf_egress_space.id
+  host   = local.egress_host
+  destinations = [{
+    app_id = cloudfoundry_app.egress_app.id
+  }]
+}
+
+locals {
+  creds = { for name, config in local.configuration : name => {
+    https_proxy = "https://${config.user_name}:${random_password.password[name].result}@${local.domain}:61443"
+    http_proxy  = "http://${config.user_name}:${random_password.password[name].result}@${local.domain}:8080"
+    username    = config.user_name
+    password    = random_password.password[name].result
+  } }
+  domain     = cloudfoundry_route.egress_route.url
+  https_port = 61443
+  http_port  = 8080
+}

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,12 @@ resource "random_password" "password" {
   special  = false
 }
 
+resource "random_uuid" "random_username" {}
+resource "random_password" "random_password" {
+  length  = 16
+  special = false
+}
+
 data "archive_file" "src" {
   type        = "zip"
   source_dir  = "${path.module}/proxy"
@@ -41,7 +47,9 @@ resource "cloudfoundry_app" "egress_app" {
 
   environment = merge(
     {
-      CADDY_LOG_LEVEL = "INFO"
+      CADDY_LOG_LEVEL       = "INFO"
+      PROXY_RANDOM_USERNAME = random_uuid.random_username.result
+      PROXY_RANDOM_PASSWORD = random_password.random_password.result
       CONFIG_CONTENT = templatefile("${path.module}/Caddyfile.tftpl", {
         configuration = values(local.configuration)
       })

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,44 @@
+output "https_proxy" {
+  value     = { for name, creds in local.creds : name => creds.https_proxy }
+  sensitive = true
+}
+
+output "http_proxy" {
+  value     = { for name, creds in local.creds : name => creds.http_proxy }
+  sensitive = true
+}
+
+output "domain" {
+  value = local.domain
+}
+
+output "http_port" {
+  value = local.http_port
+}
+
+output "https_port" {
+  value = local.https_port
+}
+
+output "username" {
+  value = { for name, creds in local.creds : name => creds.username }
+}
+
+output "password" {
+  value     = { for name, creds in local.creds : name => creds.password }
+  sensitive = true
+}
+
+output "app_id" {
+  value = cloudfoundry_app.egress_app.id
+}
+
+output "json_credentials" {
+  value = jsonencode({
+    "credentials" = local.creds
+    "domain"      = local.domain
+    "https_port"  = local.https_port
+    "http_port"   = local.http_port
+  })
+  sensitive = true
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,10 +1,10 @@
 output "https_proxy" {
-  value     = { for name, creds in local.creds : name => creds.https_proxy }
+  value     = { for name, creds in local.creds : name => creds.https_uri }
   sensitive = true
 }
 
 output "http_proxy" {
-  value     = { for name, creds in local.creds : name => creds.http_proxy }
+  value     = { for name, creds in local.creds : name => creds.http_uri }
   sensitive = true
 }
 
@@ -13,11 +13,11 @@ output "domain" {
 }
 
 output "http_port" {
-  value = local.http_port
+  value = local.common_json.http_port
 }
 
 output "https_port" {
-  value = local.https_port
+  value = local.common_json.https_port
 }
 
 output "username" {
@@ -34,11 +34,6 @@ output "app_id" {
 }
 
 output "json_credentials" {
-  value = jsonencode({
-    "credentials" = local.creds
-    "domain"      = local.domain
-    "https_port"  = local.https_port
-    "http_port"   = local.http_port
-  })
+  value     = length(local.configuration) == 1 ? local.single_client_json : local.multi_client_json
   sensitive = true
 }

--- a/providers.tf
+++ b/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry/cloudfoundry"
-      version = ">=1.4.0"
+      version = ">=1.6.0"
     }
   }
 }

--- a/providers.tf
+++ b/providers.tf
@@ -7,5 +7,3 @@ terraform {
     }
   }
 }
-
-provider "cloudfoundry" {}

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = "~> 1.10"
+  required_providers {
+    cloudfoundry = {
+      source  = "cloudfoundry/cloudfoundry"
+      version = ">=1.4.0"
+    }
+  }
+}
+
+provider "cloudfoundry" {}

--- a/proxy/.profile
+++ b/proxy/.profile
@@ -42,12 +42,6 @@ if [ -n "$VCAP_APPLICATION" ]; then
 fi
 export https_proxy="$proxy_scheme://$PROXY_USERNAME:$PROXY_PASSWORD@$proxy_host:$proxy_port"
 
-# Make open ports configurable via the PROXY_PORTS environment variable.
-# For example "80 443 22 61443". Default to 443 only.
-if [ -z "${PROXY_PORTS}" ]; then
-  export PROXY_PORTS="443"
-fi
-
 echo
 echo
 echo "The proxy connection URL is:"

--- a/proxy/.profile
+++ b/proxy/.profile
@@ -6,8 +6,6 @@
 # a flavor of busybox).
 ENABLE_ASH_BASH_COMPAT=1
 
-set -e
-
 # Newline Terminate Non-Empty File If Not Already aka ntnefina
 # https://stackoverflow.com/a/10082466/17138235
 #
@@ -35,20 +33,4 @@ else
 
   ntnefina deny.acl
   ntnefina allow.acl
-
-  # Make it easy to run curl tests on ourselves both locally and deployed
-  proxy_scheme="http"
-  proxy_host="localhost"
-  proxy_port="8080"
-  if [ -n "$VCAP_APPLICATION" ]; then
-    proxy_scheme="https"
-    proxy_host=`echo "$VCAP_APPLICATION" | jq -r '.application_uris[0]'`
-    proxy_port="61443"
-  fi
-  export https_proxy="$proxy_scheme://$PROXY_USERNAME:$PROXY_PASSWORD@$proxy_host:$proxy_port"
-
-  echo
-  echo
-  echo "The proxy connection URL is:"
-  echo "  $https_proxy"
 fi

--- a/proxy/Caddyfile
+++ b/proxy/Caddyfile
@@ -6,27 +6,25 @@
 	debug
 	log {
 		format console
-		level INFO
+		level {$CADDY_LOG_LEVEL:INFO}
 	}
 	auto_https off
 }
 
 :{$PORT} {
-	route {
-		forward_proxy {
-			basic_auth {$PROXY_USERNAME} {$PROXY_PASSWORD}
-			acl {
-				deny_file deny.acl
-				allow_file allow.acl
-				deny all
-			}
-			ports {$PROXY_PORTS}
-			serve_pac
+	forward_proxy {
+		basic_auth {$PROXY_USERNAME} {$PROXY_PASSWORD}
+		probe_resistance
+		acl {
+			deny_file deny.acl
+			allow_file allow.acl
+			deny all
 		}
+		ports {$PROXY_PORTS:443}
 	}
 	log {
 		format json
-		level INFO
+		level {$CADDY_LOG_LEVEL:INFO}
 		output stdout
 	}
 }

--- a/proxy/export_http_proxy.sh
+++ b/proxy/export_http_proxy.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+# export http(s)_proxy variables. This script should be sourced to be effective
+
+
+# Despite the temptation to use #!/bin/bash, we want to keep this file as as
+# POSIX sh-compatible as possible. This is to facilitate testing the .profile
+# under Alpine, which doesn't have /bin/bash, but does have ash (which is itself
+# a flavor of busybox).
+ENABLE_ASH_BASH_COMPAT=1
+
+# Make it easy to run curl tests on ourselves both locally and deployed
+http_proxy_host="localhost"
+http_proxy_port="8080"
+if [ -n "$VCAP_APPLICATION" ]; then
+  https_proxy_scheme="https"
+  https_proxy_host=$(echo "$VCAP_APPLICATION" | jq -r '.application_uris[0]')
+  https_proxy_port="61443"
+else
+  https_proxy_scheme="http"
+  https_proxy_host="localhost"
+  https_proxy_port="8080"
+fi
+
+if [ -n "$1" ]; then
+  username_var=PROXY_USERNAME_$1
+  PROXY_USERNAME=$(eval "echo \$$username_var")
+  password_var=PROXY_PASSWORD_$1
+  PROXY_PASSWORD=$(eval "echo \$$password_var")
+fi
+
+if [ -n "$PROXY_USERNAME" ]; then
+  export http_proxy="http://$PROXY_USERNAME:$PROXY_PASSWORD@$http_proxy_host:$http_proxy_port"
+  export https_proxy="$https_proxy_scheme://$PROXY_USERNAME:$PROXY_PASSWORD@$https_proxy_host:$https_proxy_port"
+else
+  echo "Error, no credentials found"
+  echo "Usage: 'source ./export_http_proxy.sh CLIENT_SAFE_NAME'"
+fi
+
+if [ -n "$http_proxy" ]; then
+  echo
+  echo "The proxy connection URLs are:"
+  echo "http_proxy: $http_proxy"
+  echo "https_proxy: $https_proxy"
+fi

--- a/tests/creation.tftest.hcl
+++ b/tests/creation.tftest.hcl
@@ -42,7 +42,7 @@ run "test_proxy_creation" {
   }
 
   assert {
-    condition     = output.password == { for name, _ in var.client_configuration : name => random_password.password[name].result }
+    condition     = output.password == { for name, _ in var.client_configuration : name => random_password.client_password[name].result }
     error_message = "Output password must come from the random_password resource"
   }
 

--- a/tests/creation.tftest.hcl
+++ b/tests/creation.tftest.hcl
@@ -1,0 +1,89 @@
+mock_provider "cloudfoundry" {
+  mock_data "cloudfoundry_domain" {
+    defaults = {
+      id = "682327e2-9beb-4a17-ab0c-64f4b6a96a39"
+    }
+  }
+  mock_resource "cloudfoundry_app" {
+    defaults = {
+      id = "2ccdc746-e68e-4ffa-9417-544966983719"
+    }
+  }
+}
+
+variables {
+  cf_org_name = "gsa-tts-devtools-prototyping"
+  cf_egress_space = {
+    id   = "5178d8f5-d19a-4782-ad07-467822480c68"
+    name = "terraform-cloudgov-ci-tests-egress"
+  }
+  name = "terraform-egress-app"
+  client_configuration = {
+    "feedabee" = {
+      allowlist = ["raw.githubusercontent.com:443"]
+    }
+  }
+}
+
+run "test_proxy_creation" {
+  assert {
+    condition     = output.https_proxy == { for name, _ in var.client_configuration : name => "https://${output.username["feedabee"]}:${output.password["feedabee"]}@${output.domain}:61443" }
+    error_message = "HTTPS_PROXY output must match the correct form, got ${nonsensitive(output.https_proxy["feedabee"])}"
+  }
+
+  assert {
+    condition     = output.domain == cloudfoundry_route.egress_route.url
+    error_message = "Output domain must match the route url"
+  }
+
+  assert {
+    condition     = output.username == { for name, config in local.configuration : name => config.user_name }
+    error_message = "Output username must come from the random_uuid resource"
+  }
+
+  assert {
+    condition     = output.password == { for name, _ in var.client_configuration : name => random_password.password[name].result }
+    error_message = "Output password must come from the random_password resource"
+  }
+
+  assert {
+    condition     = output.app_id == cloudfoundry_app.egress_app.id
+    error_message = "Output app_id is the egress_app's ID"
+  }
+
+  assert {
+    condition     = output.https_port == 61443
+    error_message = "https_port only supports 61443 internal https listener"
+  }
+
+  assert {
+    condition     = output.http_port == 8080
+    error_message = "http_port reports port 8080 for plaintext"
+  }
+
+}
+
+run "test_specific_hostname_bug" {
+  variables {
+    cf_org_name = "gsa-tts-devtools-prototyping"
+    cf_egress_space = {
+      id   = "169c6e21-2513-43f7-bbff-80cc5e456882"
+      name = "rca-tfm-stage-egress"
+    }
+    name = "egress-proxy-staging"
+  }
+  assert {
+    condition     = can(regex("[a-z]", substr(local.egress_host, 0, 1)))
+    error_message = "proxy domain must start with an alpha character"
+  }
+}
+
+run "test_custom_hostname_is_trimmed" {
+  variables {
+    route_host = "-3host-name"
+  }
+  assert {
+    condition     = local.egress_host == "host-name"
+    error_message = "proxy domain is stripped of any non-alpha characters"
+  }
+}

--- a/tests/creation.tftest.hcl
+++ b/tests/creation.tftest.hcl
@@ -27,7 +27,7 @@ variables {
 
 run "test_proxy_creation" {
   assert {
-    condition     = output.https_proxy == { for name, _ in var.client_configuration : name => "https://${output.username["feedabee"]}:${output.password["feedabee"]}@${output.domain}:61443" }
+    condition     = output.https_proxy == { for name, _ in var.client_configuration : name => "https://${output.username[name]}:${output.password[name]}@${output.domain}:61443" }
     error_message = "HTTPS_PROXY output must match the correct form, got ${nonsensitive(output.https_proxy["feedabee"])}"
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,52 @@
+variable "cf_org_name" {
+  type        = string
+  description = "cloud.gov organization name"
+}
+
+variable "cf_egress_space" {
+  type = object({
+    id   = string
+    name = string
+  })
+  description = "cloud.gov space egress"
+}
+
+variable "name" {
+  type        = string
+  description = "name of the egress proxy application"
+}
+
+variable "route_host" {
+  type        = string
+  default     = null
+  description = "Hostname to access the egress proxy on apps.internal domain (optional)"
+}
+
+variable "client_configuration" {
+  type = map(object({
+    # See the upstream documentation for possible acl strings:
+    #   https://github.com/caddyserver/forwardproxy/blob/master/README.md#caddyfile-syntax-server-configuration
+    allowlist = optional(set(string), [])
+    denylist  = optional(set(string), [])
+    ports     = optional(set(number), [443])
+  }))
+  description = "Configuration map {client_name => config}"
+}
+
+variable "enable_ssh" {
+  type        = bool
+  default     = false
+  description = "Whether to allow ssh into the egress app"
+}
+
+variable "egress_memory" {
+  type        = string
+  default     = "64M"
+  description = "Memory to allocate to egress proxy app, including unit"
+}
+
+variable "instances" {
+  type        = number
+  default     = 2
+  description = "the number of instances of the HTTPS proxy application to run (default: 2)"
+}


### PR DESCRIPTION
closes #88 

## Changes

* add terraform files to deploy proxy as a terraform module from here (will deprecate `terraform-cloudgov` module)
* Instead of a global allowlist, denylist, allowports, configuration takes a map of client names to those config values. Caddy will then pass the request to the config that has the proper credentials to process it.

## Not changed

The egress proxy should remain fully compatible for deployments using either the `terraform-cloudgov` module or the `bin/` script in this repo, though those will both keep the existing single-client configuration provided by `proxy/Caddyfile`