### PR TITLE
Ignore route domain changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,6 +72,10 @@ resource "cloudfoundry_route" "egress_route" {
   domain = data.cloudfoundry_domain.internal_domain.id
   space  = var.cf_egress_space.id
   host   = local.egress_host
+
+  lifecycle {
+    ignore_changes = [domain]
+  }
 }
 
 locals {


### PR DESCRIPTION
This prevents unnecessary replacement of the egress app when terraform decides to refresh the data source for the "apps.internal" domain and say that it can't figure it out until after apply.

If, for whatever reason, the `apps.internal` domain does get a new ID, then we probably have bigger problems than needing to manually pass `-replace=` to our plan and apply.