### PR TITLE
Replace .profile use with run.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,9 @@ RUN apk add --no-cache jq curl
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 COPY Caddyfile /etc/caddy/Caddyfile
 COPY export_http_proxy.sh /srv/
-COPY .profile /srv/.profile
-COPY --chmod=0755 docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
+COPY run.sh /srv/
 
 EXPOSE 8080
 
-ENTRYPOINT [ "/usr/bin/docker-entrypoint.sh" ]
+ENTRYPOINT [ "/srv/run.sh" ]
 CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--watch"]

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,6 @@ data "archive_file" "src" {
   type        = "zip"
   source_dir  = "${path.module}/proxy"
   output_path = "${path.module}/dist/src.zip"
-  excludes    = ["docker-entrypoint.sh"]
 }
 
 locals {
@@ -42,7 +41,7 @@ resource "cloudfoundry_app" "egress_app" {
   path             = data.archive_file.src.output_path
   source_code_hash = data.archive_file.src.output_base64sha256
   buildpacks       = ["binary_buildpack"]
-  command          = "./caddy run --config Caddyfile"
+  command          = "./run.sh ./caddy run --config Caddyfile"
   memory           = var.egress_memory
   instances        = var.instances
   strategy         = "rolling"

--- a/manifest.yml
+++ b/manifest.yml
@@ -11,7 +11,7 @@ applications:
     health-check-type: process
     instances: 2
     memory: 64M
-    command: ./caddy run --config Caddyfile
+    command: ./run.sh ./caddy run --config Caddyfile
     env:
       PROXY_USERNAME: ((username))
       PROXY_PASSWORD: ((password))

--- a/proxy/docker-entrypoint.sh
+++ b/proxy/docker-entrypoint.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-# This entrypoint will facilitate a local Docker run of cg-egress-proxy coming as close as possible
-# to what happens on cloud.gov with the binary_buildpack
-
-# source .profile to set up allow.acl and deny.acl
-. .profile
-
-exec "$@"

--- a/proxy/run.sh
+++ b/proxy/run.sh
@@ -34,3 +34,5 @@ else
   ntnefina deny.acl
   ntnefina allow.acl
 fi
+
+exec "$@"


### PR DESCRIPTION
Apparently, if you use a module source more than once in your root module, then all but the first one will [silently drop all hidden files](https://github.com/hashicorp/terraform/issues/30740).

This PR replaces the use of `.profile` with a wrapper `run.sh` script to do the same jobs.