### PR TITLE
Add ability to trigger regenerating the proxy passwords

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,16 +4,28 @@ locals {
   egress_host        = replace(lower(substr(coalesce(var.route_host, local.default_route_host), -63, -1)), "/^[^a-z]*/", "")
 }
 
+resource "terraform_data" "credential_key" {
+  input = var.credential_version
+}
+
 resource "random_password" "client_password" {
   for_each = var.client_configuration
   length   = 16
   special  = false
+
+  lifecycle {
+    replace_triggered_by = [terraform_data.credential_key]
+  }
 }
 
 resource "random_uuid" "random_username" {}
 resource "random_password" "random_password" {
   length  = 16
   special = false
+
+  lifecycle {
+    replace_triggered_by = [terraform_data.credential_key]
+  }
 }
 
 data "archive_file" "src" {

--- a/variables.tf
+++ b/variables.tf
@@ -50,3 +50,9 @@ variable "instances" {
   default     = 2
   description = "the number of instances of the HTTPS proxy application to run (default: 2)"
 }
+
+variable "credential_version" {
+  type        = string
+  default     = "1"
+  description = "Version string to trigger credential rotation when changed"
+}


### PR DESCRIPTION
This PR adds an optional input that will trigger replacement of the random password and client passwords, useful in cases where we need to rotate credentials across a full system.

There are no rules for `credential_version` other than it's a string. Any change will cause the replace triggers to fire.