### PR TITLE
Patch SARIF results with locations for govulncheck compliance

### DIFF
--- a/.github/workflows/vulnscan.yml
+++ b/.github/workflows/vulnscan.yml
@@ -45,6 +45,16 @@ jobs:
             ))
           ' caddy-report.sarif > caddy-report-dedup.sarif
           mv caddy-report-dedup.sarif caddy-report.sarif
+      - name: patch SARIF with locations
+        run: |
+          jq '
+            (.runs[]?.results[]? |= (
+              if (.locations|not) and (.codeFlows[0].threadFlows[0].locations[0]) then
+                .locations = [ .codeFlows[0].threadFlows[0].locations[0] ]
+              else . end
+            ))
+            ' caddy-report.sarif > caddy-report-patched.sarif
+          mv caddy-report-patched.sarif caddy-report.sarif
       - name: upload artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Problem

govulncheck SARIF output in binary mode is missing the required  array in each result, causing SARIF upload to fail on GitHub.

## Fix

- Patch each result to add a  array, copying the first location from the first threadFlow if missing

This is a workaround for a known limitation in govulncheck/go SARIF output.

## Validation

- All results have a valid location array
- Workflow lints cleanly
