### PR TITLE
Ensure deduplication is the final step in SARIF workflow

### DIFF
--- a/.github/workflows/vulnscan.yml
+++ b/.github/workflows/vulnscan.yml
@@ -57,8 +57,12 @@ jobs:
         run: |
           jq '
             (.runs[]?.results[]? |= (
-              if (.locations|not) and (.codeFlows[0].threadFlows[0].locations[0].location) then
-                .locations = [ .codeFlows[0].threadFlows[0].locations[0].location ]
+              if (.locations|not) then
+                if (.codeFlows[0]?.threadFlows[0]?.locations[0]?.location) then
+                  .locations = [ .codeFlows[0].threadFlows[0].locations[0].location ]
+                else
+                  .locations = [{"physicalLocation": {"artifactLocation": {"uri": "UNKNOWN"}}}]
+                end
               else . end
               | (if .stacks then .stacks |= unique else . end)
               | (if .codeFlows then .codeFlows[]?.threadFlows |= unique else . end)
@@ -72,7 +76,6 @@ jobs:
           name: govulncheck-sarif
           path: caddy-report.sarif
       - name: upload results
-        continue-on-error: true
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: caddy-report.sarif

--- a/.github/workflows/vulnscan.yml
+++ b/.github/workflows/vulnscan.yml
@@ -55,6 +55,16 @@ jobs:
             ))
             ' caddy-report.sarif > caddy-report-patched.sarif
           mv caddy-report-patched.sarif caddy-report.sarif
+      - name: deduplicate sarif (final)
+        run: |
+          jq '
+            (.runs[]?.tool.driver.rules[]?.properties.tags) |= unique
+            | (.runs[]?.results[]? |= (
+              (if .stacks then .stacks |= unique else . end)
+              | (if .codeFlows then .codeFlows[]?.threadFlows |= unique else . end)
+            ))
+          ' caddy-report.sarif > caddy-report-dedup.sarif
+          mv caddy-report-dedup.sarif caddy-report.sarif
       - name: upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/vulnscan.yml
+++ b/.github/workflows/vulnscan.yml
@@ -35,36 +35,37 @@ jobs:
         run: govulncheck -mode binary proxy/caddy
       - name: run check (sarif)
         run: govulncheck -mode binary -format sarif proxy/caddy > caddy-report.sarif
-      - name: deduplicate sarif
-        run: |
-          jq '
-            (.runs[]?.tool.driver.rules[]?.properties.tags) |= unique
-            | (.runs[]?.results[]? |= (
-              (if .stacks then .stacks |= unique else . end)
-              | (if .codeFlows then .codeFlows[]?.threadFlows |= unique else . end)
-            ))
-          ' caddy-report.sarif > caddy-report-dedup.sarif
-          mv caddy-report-dedup.sarif caddy-report.sarif
-      - name: patch SARIF with locations
+      # govulncheck SARIF output is not GitHub-compliant for two reasons:
+      #   #
+      #   # 1. Missing locations:
+      #   #    - SARIF requires each result to have a `locations` array, but govulncheck (in binary mode)
+      #   #      does not emit this field. This causes SARIF upload to GitHub to fail schema validation.
+      #   #    - The workaround is to patch each result with a `locations` array, copying the first
+      #   #      available `.location` from the first threadFlow if present. This is a common workaround
+      #   #      discussed in Go and GitHub issue trackers, as the govulncheck maintainers have not yet
+      #   #      addressed this limitation (see golang/go#65694 and related issues).
+      #   #
+      #   # 2. Duplicate arrays:
+      #   #    - govulncheck SARIF output may contain duplicate entries in arrays such as
+      #   #      `results[].stacks`, `results[].codeFlows[].threadFlows`, and `tool.driver.rules[].properties.tags`.
+      #   #      The SARIF spec requires all arrays with `uniqueItems: true` to be deduplicated, and GitHub
+      #   #      upload will fail if duplicates are present.
+      #   #    - Deduplication is necessary to ensure SARIF schema compliance and successful upload.
+      #   #
+      # This step patches missing locations and deduplicates all arrays in one pass.
+      - name: patch and deduplicate SARIF for GitHub
         run: |
           jq '
             (.runs[]?.results[]? |= (
               if (.locations|not) and (.codeFlows[0].threadFlows[0].locations[0].location) then
                 .locations = [ .codeFlows[0].threadFlows[0].locations[0].location ]
               else . end
-            ))
-            ' caddy-report.sarif > caddy-report-patched.sarif
-          mv caddy-report-patched.sarif caddy-report.sarif
-      - name: deduplicate sarif (final)
-        run: |
-          jq '
-            (.runs[]?.tool.driver.rules[]?.properties.tags) |= unique
-            | (.runs[]?.results[]? |= (
-              (if .stacks then .stacks |= unique else . end)
+              | (if .stacks then .stacks |= unique else . end)
               | (if .codeFlows then .codeFlows[]?.threadFlows |= unique else . end)
             ))
-          ' caddy-report.sarif > caddy-report-dedup.sarif
-          mv caddy-report-dedup.sarif caddy-report.sarif
+            | (.runs[]?.tool.driver.rules[]?.properties.tags) |= unique
+          ' caddy-report.sarif > caddy-report-fixed.sarif
+          mv caddy-report-fixed.sarif caddy-report.sarif
       - name: upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/vulnscan.yml
+++ b/.github/workflows/vulnscan.yml
@@ -49,8 +49,8 @@ jobs:
         run: |
           jq '
             (.runs[]?.results[]? |= (
-              if (.locations|not) and (.codeFlows[0].threadFlows[0].locations[0]) then
-                .locations = [ .codeFlows[0].threadFlows[0].locations[0] ]
+              if (.locations|not) and (.codeFlows[0].threadFlows[0].locations[0].location) then
+                .locations = [ .codeFlows[0].threadFlows[0].locations[0].location ]
               else . end
             ))
             ' caddy-report.sarif > caddy-report-patched.sarif

--- a/.github/workflows/vulnscan.yml
+++ b/.github/workflows/vulnscan.yml
@@ -64,6 +64,7 @@ jobs:
                   .locations = [{"physicalLocation": {"artifactLocation": {"uri": "UNKNOWN"}}}]
                 end
               else . end
+              | (.locations[]?.physicalLocation.artifactLocation.uri |= (if . == null or . == "" then "UNKNOWN" else . end))
               | (if .stacks then .stacks |= unique else . end)
               | (if .codeFlows then .codeFlows[]?.threadFlows |= unique else . end)
             ))


### PR DESCRIPTION
This PR ensures that deduplication of all SARIF arrays (tags, stacks, threadFlows) is performed as the final step after patching locations, guaranteeing schema compliance for GitHub upload.\n\n- Patch locations from threadFlows if missing\n- Deduplicate all arrays as the last step\n- Validated locally against the SARIF 2.1.0 schema\n\nThis should resolve all remaining SARIF validation issues.