### PR TITLE
Update caddy & actions jobs

### DIFF
--- a/.github/workflows/keep-binary-updated.yml
+++ b/.github/workflows/keep-binary-updated.yml
@@ -20,7 +20,7 @@ jobs:
   keep-binary-up-to-date:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Regenerate binary
@@ -34,7 +34,7 @@ jobs:
           echo "binaryupdated=${binaryupdated}" >> $GITHUB_OUTPUT
       - name: Create PR with changes
         if: steps.vars.outputs.binaryupdated != 0
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: Update binary for ${{ github.ref_name }}
           title: Update caddy binary for ${{ github.ref_name }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     name: Validate terraform configuration
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -26,7 +26,7 @@ jobs:
     name: Check formatting of terraform files
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: build caddy - setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: 'stable'
       - name: build caddy - get xcaddy

--- a/.github/workflows/test_tf.yml
+++ b/.github/workflows/test_tf.yml
@@ -18,7 +18,7 @@ jobs:
         apt-get install -y zip
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: terraform test

--- a/.github/workflows/validate-oscal.yml
+++ b/.github/workflows/validate-oscal.yml
@@ -17,7 +17,7 @@ jobs:
     name: Validate component definition format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -30,7 +30,7 @@ jobs:
     name: Check assembly is current
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -44,7 +44,7 @@ jobs:
 
       - name: Comment on pull request
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const output = `OSCAL assembly detected changes that aren't checked in.

--- a/.github/workflows/vulnscan.yml
+++ b/.github/workflows/vulnscan.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: 'stable'
       - name: install govulncheck
@@ -74,7 +74,7 @@ jobs:
           ' caddy-report.sarif > caddy-report-fixed.sarif
           mv caddy-report-fixed.sarif caddy-report.sarif
       - name: upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: govulncheck-sarif
           path: caddy-report.sarif


### PR DESCRIPTION
If updating the version and binary doesn't get the job passing again, then we likely need to look at either LFS or on-demand building for the caddy binary file.